### PR TITLE
fix(ks): change LDAP admin user

### DIFF
--- a/ks.cfg
+++ b/ks.cfg
@@ -64,7 +64,7 @@ fi
 
 # Add an internal provider to the cluster
 api-cli run cluster/add-internal-provider --data '{"image": "openldap", "node": 1}'
-api-cli run module/openldap1/configure-module --data '{"provision":"new-domain","admuser":"admin","admpass":"Nethesis,1234","domain":"ns8.local"}'
+api-cli run module/openldap1/configure-module --data '{"provision":"new-domain","admuser":"administrator","admpass":"Nethesis,1234","domain":"ns8.local"}'
 
 if [ \$? -eq 0 ]; then
   echo "Internal provider addition completed successfully." >> /var/log/ns8-install.log


### PR DESCRIPTION
As default, the UI proposes 'administrator': let's keep this value to preserve uniformity