### PR TITLE
fix: update disk partitioning configuration in ks.cfg

### DIFF
--- a/ks.cfg
+++ b/ks.cfg
@@ -17,8 +17,14 @@ text
 reboot --eject
 
 # Disk partitioning
-clearpart --all
-autopart --type=lvm
+clearpart --all --initlabel
+
+part /boot --fstype="xfs" --size=1024
+part pv.01 --size=1 --grow
+volgroup vg_ns8 pv.01
+logvol / --fstype="xfs" --name=lv_root --vgname=vg_ns8 --size=1 --grow
+logvol swap --name=lv_swap --vgname=vg_ns8 --size=4096
+
 
 # Bootloader configuration
 bootloader --location=mbr


### PR DESCRIPTION
This pull request updates the disk partitioning section of the `ks.cfg` file to provide a more explicit and customized partition layout. The changes replace the use of automatic partitioning with manual definitions, specifying partitions for `/boot`, swap, and the root filesystem using LVM.

Disk partitioning changes:

* Added `--initlabel` to `clearpart` and replaced `autopart` with manual partition definitions, including a dedicated `/boot` partition, a physical volume for LVM, a volume group (`vg_ns8`), and logical volumes for root (`/`) and swap.